### PR TITLE
feat: Make OpenSearch score threshold configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# OpenAI Config
+OPENAI_API_KEY=sk-YOUR_OPENAI_API_KEY_HERE
+OPENAI_API_URL=https://api.openai.com/v1
+OPENAI_EMBED_MODEL=text-embedding-ada-002
+
+# OpenSearch Config
+OPENSEARCH_HOST=localhost
+OPENSEARCH_PORT=9200
+OPENSEARCH_INDEX_NAME=redmine_index
+EMBED_DIM=1536
+DEFAULT_K=25
+OPENSEARCH_SCORE_THRESHOLD=0.75 # Default score threshold for OpenSearch KNN results
+
+# Optional: Set Node.js environment (e.g., development, production)
+# NODE_ENV=development

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
 const express = require('express');
 const { WebSocketServer } = require('ws');
 const { Client } = require('@opensearch-project/opensearch');
 const OpenAI = require('openai');
-const dotenv = require('dotenv');
 const cookie = require('cookie');
 const jwt = require('jsonwebtoken');
 
 const { planAndExecute } = require('./agenticPlanner');
 const { runSteps } = require('./executePlan');
-
-dotenv.config();
 
 const {
     OPENAI_API_KEY,


### PR DESCRIPTION
- Introduce OPENSEARCH_SCORE_THRESHOLD environment variable to control the minimum score for KNN search results in executePlan.js.
- Update .env.example with the new threshold variable.
- Ensure dotenv.config() is called at the top of index.js before other modules are loaded, allowing environment variables to be available during module initialization.