### PR TITLE
docs: Improve README with setup instructions and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A dynamic, LLM-based Retrieval-Augmented Generation (RAG) or Retrieval-Augmented
 
 ---
 
-``` mermaid
+```mermaid
 graph TD
     A[User Query via REST or WebSocket] --> B[Planner using GPT-4o]
     B --> C[Intent and Entity Extraction]
@@ -24,32 +24,69 @@ graph TD
 
 ## ⚙️ Core Features
 
-* **Agentic/LLM-based Planner + Executor Loop**
+- **Agentic/LLM-based Planner + Executor Loop**
   Leverages GPT-4o to extract entities, expand terms, and build a multi-step ANN plan from natural queries.
 
-* **ANN Search via OpenSearch (HNSW)**
+- **ANN Search via OpenSearch (HNSW)**
   Efficient vector search over document embeddings using 'knn_vector' with score threshold filtering.
 
-* **Interleaved Multi-Entity Result Retrieval**
+- **Interleaved Multi-Entity Result Retrieval**
   Returns top-k interleaved results across query entities (X1, Y1, Z1, X2 ...) to ensure balanced relevance.
 
-* **WebSocket + REST API Support**
+- **WebSocket + REST API Support**
   Real-time and stateless access methods for seamless front-end integration.
 
 ---
 
 ## 🧰 Tech Stack
 
-| Component       | Technology                        |
-| --------------- | --------------------------------- |
-| API Server      | Node.js + Express.js              |
-| Embeddings      | OpenAI (text-embedding-ada-002)   |
-| Search Engine   | OpenSearch (HNSW, KNN)            |
-| Planner Model   | GPT-4o                            |
-| Socket Support  | WebSocket Server (WSS)            |
-| Auth            | JWT                               |
+| Component      | Technology                      |
+| -------------- | ------------------------------- |
+| API Server     | Node.js + Express.js            |
+| Embeddings     | OpenAI (text-embedding-ada-002) |
+| Search Engine  | OpenSearch (HNSW, KNN)          |
+| Planner Model  | GPT-4o                          |
+| Socket Support | WebSocket Server (WSS)          |
+| Auth           | JWT                             |
 
 ---
+
+## System Overview & Document Ingestion
+
+The `rass-engine` is the querying backend of a Retrieval Augmented Semantic Search system. It is designed to interpret natural language queries, generate search plans, and retrieve relevant documents from an OpenSearch index.
+
+**Important Note on Document Ingestion:** This `rass-engine` **does not handle document ingestion** (uploading, chunking, embedding, and indexing into OpenSearch). This process is managed by a separate service.
+
+For the intended workflow, you will need to use the **[embedding-service](https://github.com/NeuralRevenant/embedding-service)** (or your own compatible ingestion pipeline) to populate your OpenSearch index (`redmine_index` by default) with document embeddings. Once documents are ingested into OpenSearch by the `embedding-service`, the `rass-engine` can then query them.
+
+---
+
+## Prerequisites
+
+- **OpenSearch:** This engine requires a running OpenSearch (or Elasticsearch compatible) instance. For local development, Docker is a convenient way to run OpenSearch.
+
+  ```bash
+  # Example Docker command for OpenSearch (adjust memory as needed, e.g., -Xms1g -Xmx1g for 1GB)
+  docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" --name opensearch-node -d opensearchproject/opensearch:latest
+  ```
+
+- **WSL Users:** If running Docker Desktop on WSL (Windows Subsystem for Linux) for OpenSearch, you will likely need to increase the vm.max_map_count setting on your WSL distribution. To set this temporarily (resets on WSL restart):
+
+  ```bash
+  sudo sysctl -w vm.max_map_count=262144
+  ```
+
+  For a permanent change, add the following line to `/etc/sysctl.conf`:
+
+  ```bash
+  vm.max_map_count=262144
+  ```
+
+- **Node.js and npm:** Ensure you have Node.js (v18 or later) and npm installed. You can check your versions with:
+  ```bash
+  node -v
+  npm -v
+  ```
 
 ## 🚀 Getting Started
 
@@ -65,24 +102,37 @@ npm install
 
 Create a `.env` file:
 
-```ini
-# OpenAI Config
-OPENAI_API_KEY=sk-...
-OPENAI_API_URL=https://api.openai.com/v1
-OPENAI_EMBED_MODEL=text-embedding-ada-002
+Create a `.env` file in the project root by copying the `.env.example` template (if available) or by creating a new file. Populate it with the following variables:
 
-# OpenSearch Config
-OPENSEARCH_HOST=localhost
-OPENSEARCH_PORT=9200
-OPENSEARCH_INDEX_NAME=redmine_index
-EMBED_DIM=1536
-DEFAULT_K=25
+```dotenv
+# OpenAI Configuration
+OPENAI_API_KEY=sk-YOUR_OPENAI_API_KEY_HERE
+OPENAI_API_URL=[https://api.openai.com/v1](https://api.openai.com/v1)        # Default, change if using a proxy
+OPENAI_EMBED_MODEL=text-embedding-ada-002 # Model used for generating embeddings
+
+# OpenSearch Configuration
+OPENSEARCH_HOST=localhost                     # Hostname for your OpenSearch instance
+OPENSEARCH_PORT=9200                          # Port for your OpenSearch instance
+OPENSEARCH_INDEX_NAME=redmine_index           # Target index in OpenSearch (should match index used by embedding-service)
+EMBED_DIM=1536                                # Embedding dimension for the specified OpenAI model
+
+# RASS Engine Configuration
+DEFAULT_K=25                                  # Default number of K nearest neighbors to retrieve if not specified in query
+OPENSEARCH_SCORE_THRESHOLD=0.75               # Minimum similarity score (0.0-1.0) for KNN results to be considered.
+                                              # The code uses a fallback (e.g., 0.78) if this is not set or invalid.
+
 ```
+
+Ensure the OPENSEARCH_SCORE_THRESHOLD default mentioned in the comment matches the fallback in your executePlan.js
+
+---
 
 ### 3. Start the Server
 
 ```bash
-node server.js
+npm run start
+# or alternatively
+# node index.js
 ```
 
 Server runs on: [http://localhost:8000](http://localhost:8000)
@@ -91,10 +141,10 @@ Server runs on: [http://localhost:8000](http://localhost:8000)
 
 ## 🧠 How It Works
 
-* **Natural Language Input** → `"get me records for Julian140 and documents with Borne"`
-* **LLM Planner** → Extracts entities ('Julian140', 'Borneo Elephants'), expands them (if needed), and plans vector queries
-* **Embedding Search** → Each entity/term is searched via HNSW-based ANN
-* **Results** → Interleaved top results returned, preserving per-entity relevance
+- **Natural Language Input** → `"get me records for Julian140 and documents with Borne"`
+- **LLM Planner** → Extracts entities ('Julian140', 'Borneo Elephants'), expands them (if needed), and plans vector queries
+- **Embedding Search** → Each entity/term is searched via HNSW-based ANN
+- **Results** → Interleaved top results returned, preserving per-entity relevance
 
 ---
 
@@ -173,16 +223,16 @@ Same structure as the REST `/ask` response. Connection auto-closes post-response
 
 ## 🧼 Notes
 
-* Score threshold is configurable (default ≥ `0.86`) and applied per KNN step.
-* ANN results are interleaved by entity, not globally sorted, to preserve diverse entity coverage.
-* Embeddings are cached per query step to avoid recomputation.
-* Planner auto-retries up to 6 times if no adequate coverage is achieved.
+- Score threshold for filtering KNN results is configurable via the `OPENSEARCH_SCORE_THRESHOLD` environment variable (e.g., default set to `0.75` in `.env.example`). This is applied per KNN step.
+- ANN results are interleaved by entity, not globally sorted, to preserve diverse entity coverage.
+- Embeddings are cached per query step to avoid recomputation.
+- Planner auto-retries up to 6 times if no adequate coverage is achieved.
 
 ---
 
 ## 📌 Future Enhancements for medical EHR document search
 
-* Improve the accuracy for EHR patient and medical data - FHIR, plain-text medical notes with hybrid search and proper file parsing.
-* Add a more powerful agentic AI design to enhance the retrieval accuracy like above for EHR medical documents.
-* Enable hybrid KNN + text-based search (BM25, etc. used in OpenSearch)
-* Visual result explorer (timeline or graph)
+- Improve the accuracy for EHR patient and medical data - FHIR, plain-text medical notes with hybrid search and proper file parsing.
+- Add a more powerful agentic AI design to enhance the retrieval accuracy like above for EHR medical documents.
+- Enable hybrid KNN + text-based search (BM25, etc. used in OpenSearch)
+- Visual result explorer (timeline or graph)


### PR DESCRIPTION
- Add Prerequisites section with OpenSearch setup guidance, including Docker example and WSL vm.max_map_count note.
- Add System Overview section explaining the role of rass-engine and its dependency on a separate embedding-service for document ingestion, linking to the embedding-service repository.
- Update Getting Started section to:
  - Detail all necessary environment variables, including the new OPENSEARCH_SCORE_THRESHOLD.
  - Correct the server start command.
- Update Notes section to reflect configurable score threshold.